### PR TITLE
Fix: Default to Letta Cloud instead of localhost

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Letta Cloud (recommended for most users)
+# Get your API key from: https://app.letta.com/settings
+LETTA_API_KEY=your-api-key-here
+LETTA_BASE_URL=https://api.letta.com
+
+# Optional: Use a specific agent (defaults to creating new agent)
+# LETTA_AGENT_ID=agent-xxxxx
+
+# =====================================
+# Local Development (advanced users)
+# =====================================
+# Uncomment these lines to use a local Letta server instead:
+# LETTA_BASE_URL=http://localhost:8283
+# LETTA_API_KEY=dummy  # Local server ignores this

--- a/README.md
+++ b/README.md
@@ -51,17 +51,20 @@ Agents remember across conversations (via memory blocks), but each conversation 
 
 ### Environment Setup
 
-Create a `.env` file:
+1. Copy `.env.example` to `.env`:
+   ```bash
+   cp .env.example .env
+   ```
 
-```bash
-# For Letta Cloud
-LETTA_API_KEY=your-api-key
-LETTA_BASE_URL=https://api.letta.com
+2. Get your Letta API key from [app.letta.com/settings](https://app.letta.com/settings)
 
-# For local development
-LETTA_BASE_URL=http://localhost:8283
-LETTA_API_KEY=dummy  # Local server ignores this
-```
+3. Edit `.env` and add your API key:
+   ```bash
+   LETTA_API_KEY=your-api-key-here
+   LETTA_BASE_URL=https://api.letta.com  # This is the default
+   ```
+
+**Note:** The app defaults to Letta Cloud (`https://api.letta.com`). For local development, see `.env.example` for localhost configuration.
 
 ### Running the App
 

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -17,10 +17,10 @@ try {
     }
   }
   
-  // Default to localhost if no base URL set
+  // Default to Letta Cloud if no base URL set
   if (!process.env.LETTA_BASE_URL) {
-    process.env.LETTA_BASE_URL = "http://localhost:8283";
-    console.log("Set LETTA_BASE_URL to localhost");
+    process.env.LETTA_BASE_URL = "https://api.letta.com";
+    console.log("Set LETTA_BASE_URL to Letta Cloud (api.letta.com)");
   }
   
   // Set dummy API key for localhost (local server doesn't check it)


### PR DESCRIPTION
## Summary

Improves first-time setup experience by defaulting to Letta Cloud API instead of localhost, reducing setup friction for new users.

## Problem

During setup testing, we found that the app defaulted to `http://localhost:8283`, which required users to:
1. Discover the default was wrong
2. Manually export `LETTA_BASE_URL=https://api.letta.com`
3. Restart the app

This adds unnecessary friction since most users will use Letta Cloud, not a local server.

## Changes

**`src/electron/main.ts`**
- Changed default `LETTA_BASE_URL` from `http://localhost:8283` → `https://api.letta.com`
- Updated console log message to reflect cloud default

**`.env.example` (new file)**
- Added clear setup instructions with API key link
- Shows both cloud (default) and localhost configurations
- Guides users to https://app.letta.com/settings for API key

**`README.md`**
- Updated Environment Setup section to reference `.env.example`
- Added step-by-step instructions with API key link
- Clarified that cloud is now the default

## Impact

- **Better first-run experience**: App "just works" with Letta Cloud
- **Clearer setup**: `.env.example` guides users through configuration
- **Still supports local dev**: Localhost setup is documented but not default

## Test Plan

- [x] Tested with Letta Cloud API (api.letta.com) - works out of box
- [x] Verified `.env.example` has correct format and links
- [x] Confirmed localhost setup still works when configured

👾 Generated with [Letta Code](https://letta.com)