### PR TITLE
Fix: Preserve prompt text during session start loading

### DIFF
--- a/src/ui/components/PromptInput.tsx
+++ b/src/ui/components/PromptInput.tsx
@@ -35,14 +35,15 @@ export function usePromptActions(sendEvent: (event: ClientEvent) => void) {
         type: "session.start",
         payload: { title: "", prompt, cwd: cwd.trim() || undefined, allowedTools: DEFAULT_ALLOWED_TOOLS }
       });
+      // Don't clear prompt yet - wait for modal to close to avoid UI flicker
     } else {
       if (activeSession?.status === "running") {
         setGlobalError("Session is still running. Please wait for it to finish.");
         return;
       }
       sendEvent({ type: "session.continue", payload: { sessionId: activeSessionId, prompt } });
+      setPrompt("");
     }
-    setPrompt("");
   }, [activeSession, activeSessionId, cwd, prompt, sendEvent, setGlobalError, setPendingStart, setPrompt]);
 
   const handleStop = useCallback(() => {

--- a/src/ui/store/useAppStore.ts
+++ b/src/ui/store/useAppStore.ts
@@ -180,7 +180,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 
         if (state.pendingStart) {
           get().setActiveSessionId(sessionId);
-          set({ pendingStart: false, showStartModal: false });
+          set({ pendingStart: false, showStartModal: false, prompt: "" });
         }
         break;
       }


### PR DESCRIPTION
## Summary

fixes confusing ux where the prompt text briefly disappeared and got replaced by the placeholder text during loading after clicking "Start Session"

## Problem

when u type a prompt and click "Start Session", the text would flash away while loading and the placeholder "Describe the task you want agent to handle..." would show up. made it feel like the prompt got deleted even tho it worked fine in the next screen

## Changes

**PromptInput.tsx**
- only clear prompt for `session.continue`, not `session.start`
- added comment explaining why

**useAppStore.ts**
- clear prompt when modal closes (when `session.status` received with `pendingStart` true)

## Test plan

- [x] tested typing prompt + clicking "Start Session" - text stays visible during loading
- [x] verified prompt appears correctly in conversation view
- [x] tested session.continue still clears prompt immediately (expected behavior)

👾 Generated with [Letta Code](https://letta.com)