### PR TITLE
Fix: Update settings for Letta API and hide settings button for MVP

### DIFF
--- a/src/ui/components/SettingsModal.tsx
+++ b/src/ui/components/SettingsModal.tsx
@@ -64,7 +64,7 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
         apiKey: apiKey.trim(),
         baseURL: baseURL.trim(),
         model: model.trim(),
-        apiType: "anthropic"
+        apiType: "letta"
       });
 
       if (result.success) {
@@ -99,7 +99,7 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
             </svg>
           </button>
         </div>
-        <p className="mt-2 text-sm text-muted">Supports Anthropic’s official API as well as third-party APIs compatible with the Anthropic format.</p>
+        <p className="mt-2 text-sm text-muted">Configure your Letta API connection. Get your API key from app.letta.com/settings.</p>
 
         {loading ? (
           <div className="mt-5 flex items-center justify-center py-8">
@@ -115,7 +115,7 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
               <input
                 type="url"
                 className="rounded-xl border border-ink-900/10 bg-surface-secondary px-4 py-2.5 text-sm text-ink-800 placeholder:text-muted-light focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent/20 transition-colors"
-                placeholder="htts://..."
+                placeholder="https://api.letta.com"
                 value={baseURL}
                 onChange={(e) => setBaseURL(e.target.value)}
                 required
@@ -139,7 +139,7 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
               <input
                 type="text"
                 className="rounded-xl border border-ink-900/10 bg-surface-secondary px-4 py-2.5 text-sm text-ink-800 placeholder:text-muted-light focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent/20 transition-colors"
-                placeholder="claude-3-5-sonnet-20241022"
+                placeholder="claude-sonnet-4-20250514"
                 value={model}
                 onChange={(e) => setModel(e.target.value)}
                 required

--- a/src/ui/components/Sidebar.tsx
+++ b/src/ui/components/Sidebar.tsx
@@ -80,7 +80,8 @@ export function Sidebar({
         >
           + New Task
         </button>
-        <button
+        {/* Settings button hidden for MVP - uncomment to re-enable */}
+        {/* <button
           className="rounded-xl border border-ink-900/10 bg-surface px-4 py-3 text-sm text-ink-700 hover:bg-surface-tertiary hover:border-ink-900/20 transition-colors"
           onClick={() => useAppStore.getState().setShowSettingsModal(true)}
           aria-label="Settings"
@@ -89,7 +90,7 @@ export function Sidebar({
             <circle cx="12" cy="12" r="3" />
             <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09a1.65 1.65 0 0 0-1.08-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09a1.65 1.65 0 0 0 1.51-1.08 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33h.08a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82v.08a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
           </svg>
-        </button>
+        </button> */}
       </div>
       <div className="flex flex-col gap-2 overflow-y-auto">
         {sessionList.length === 0 && (


### PR DESCRIPTION
## Summary

fixes hardcoded anthropic references in settings, url typo, outdated model, and hides settings button for mvp

## Changes

**Settings Modal (SettingsModal.tsx):**
- "Supports Anthropic's official API" → "Configure your Letta API connection"
- added link to app.letta.com/settings for getting API key
- base url placeholder: "htts://" → "https://api.letta.com"
- model placeholder: "claude-3-5-sonnet-20241022" → "claude-sonnet-4-20250514"
- apiType: "anthropic" → "letta"

**Sidebar (Sidebar.tsx):**
- commented out settings button for MVP (code kept for future)

**How model is used:**
the model name gets passed to letta CLI via `-m` flag and determines which LLM the agent uses

## Test plan

- [x] checked settings modal displays correct text and placeholders
- [x] verified settings button is hidden in sidebar
- [x] confirmed code can be easily uncommented later

👾 Generated with [Letta Code](https://letta.com)