### PR TITLE
fix: update runner.ts for new Letta Code SDK API

### DIFF
--- a/src/electron/libs/runner.ts
+++ b/src/electron/libs/runner.ts
@@ -1,7 +1,7 @@
 import {
-  createAgent,
   createSession,
   resumeSession,
+  resumeConversation,
   type Session as LettaSession,
   type SDKMessage,
   type CanUseToolResponse,
@@ -94,14 +94,13 @@ export async function runLetta(options: RunnerOptions): Promise<RunnerHandle> {
 
       if (resumeConversationId) {
         // Resume specific conversation
-        lettaSession = resumeSession(resumeConversationId, sessionOptions);
+        lettaSession = resumeConversation(resumeConversationId, sessionOptions);
       } else if (cachedAgentId) {
         // Create new conversation on existing agent
-        lettaSession = createSession(cachedAgentId, sessionOptions);
+        lettaSession = resumeSession(cachedAgentId, sessionOptions);
       } else {
-        // First time - create agent, then create conversation
-        cachedAgentId = await createAgent();
-        lettaSession = createSession(cachedAgentId, sessionOptions);
+        // First time - create fresh session (creates agent automatically)
+        lettaSession = createSession(sessionOptions);
       }
 
       // Store for abort handling

--- a/types.d.ts
+++ b/types.d.ts
@@ -18,9 +18,9 @@ type EventPayloadMapping = {
     "generate-session-title": string;
     "get-recent-cwds": string[];
     "select-directory": string | null;
-    "get-api-config": { apiKey: string; baseURL: string; model: string; apiType?: "anthropic" } | null;
+    "get-api-config": { apiKey: string; baseURL: string; model: string; apiType?: "letta" } | null;
     "save-api-config": { success: boolean; error?: string };
-    "check-api-config": { hasConfig: boolean; config: { apiKey: string; baseURL: string; model: string; apiType?: "anthropic" } | null };
+    "check-api-config": { hasConfig: boolean; config: { apiKey: string; baseURL: string; model: string; apiType?: "letta" } | null };
 }
 
 interface Window {
@@ -32,8 +32,8 @@ interface Window {
         onServerEvent: (callback: (event: any) => void) => UnsubscribeFunction;
         getRecentCwds: (limit?: number) => Promise<string[]>;
         selectDirectory: () => Promise<string | null>;
-        getApiConfig: () => Promise<{ apiKey: string; baseURL: string; model: string; apiType?: "anthropic" } | null>;
-        saveApiConfig: (config: { apiKey: string; baseURL: string; model: string; apiType?: "anthropic" }) => Promise<{ success: boolean; error?: string }>;
-        checkApiConfig: () => Promise<{ hasConfig: boolean; config: { apiKey: string; baseURL: string; model: string; apiType?: "anthropic" } | null }>;
+        getApiConfig: () => Promise<{ apiKey: string; baseURL: string; model: string; apiType?: "letta" } | null>;
+        saveApiConfig: (config: { apiKey: string; baseURL: string; model: string; apiType?: "letta" }) => Promise<{ success: boolean; error?: string }>;
+        checkApiConfig: () => Promise<{ hasConfig: boolean; config: { apiKey: string; baseURL: string; model: string; apiType?: "letta" } | null }>;
     }
 }


### PR DESCRIPTION
## Summary
- Remove `createAgent` import (no longer exists in SDK)
- Fix session creation to use correct SDK functions (`resumeConversation`, `resumeSession`, `createSession`)
- Update `types.d.ts` apiType from `"anthropic"` to `"letta"`

## Context
The Letta Code SDK API changed - agents are now created automatically when calling `createSession()`, so the explicit `createAgent()` function was removed. This PR updates the runner to use the current API.

## Test plan
- [x] `bun run build` compiles without errors
- [x] `bun run transpile:electron` succeeds
- [x] Manual test: start new session, verify agent creation works
- [x] Manual test: continue conversation, verify resumeConversation works

🐿 Generated with [Letta Code](https://letta.com)