### PR TITLE
chore: use npm package for letta-code-sdk instead of local path

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"dist:linux": "bun run transpile:electron && bun run build && electron-builder --linux --x64"
 	},
 	"dependencies": {
-		"@letta-ai/letta-code-sdk": "file:../letta-code-sdk",
+		"@letta-ai/letta-code-sdk": "^0.0.5",
 		"@radix-ui/react-dialog": "^1.1.15",
 		"@radix-ui/react-dropdown-menu": "^2.1.16",
 		"@tailwindcss/vite": "^4.1.18",


### PR DESCRIPTION
## Summary
- Switch `@letta-ai/letta-code-sdk` from `file:../letta-code-sdk` to published npm package `^0.0.5`
- Makes the project easier to set up without needing a local clone of letta-code-sdk

## Test plan
- [x] `bun install` succeeds
- [ ] App starts and creates agents normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)