### PR TITLE
chore: add bun.lock and .letta to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,9 @@ dist-electron
 *.sw?
 
 .env
+
+# Package manager
+bun.lock
+
+# Letta
+.letta/


### PR DESCRIPTION
## Summary
- Added `bun.lock` to gitignore (Bun package manager lock file)
- Added `.letta/` to gitignore (Letta configuration directory)

These files are local to each developer's environment and should not be committed to the repository.

👾 Generated with [Letta Code](https://letta.com)