### PR TITLE
fix: cross-platform compatibility for Windows and SDK API

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"main": "dist-electron/main.js",
 	"scripts": {
 		"rebuild": "npx electron-rebuild -f -w better-sqlite3",
-		"dev": "pkill -f vite 2>/dev/null; pkill -f electron 2>/dev/null; sleep 1; bun run dev:react & bun run dev:electron",
+		"dev": "concurrently -k --kill-others-on-fail \"bun run dev:react\" \"bun run dev:electron\"",
 		"dev:react": "vite",
 		"dev:electron": "bun run transpile:electron && cross-env NODE_ENV=development electron .",
 		"build": "tsc -b && vite build",
@@ -44,6 +44,7 @@
 		"@types/react": "^19.2.7",
 		"@types/react-dom": "^19.2.3",
 		"@vitejs/plugin-react": "^5.1.2",
+		"concurrently": "^9.2.1",
 		"cross-env": "^10.1.0",
 		"electron": "^39.2.7",
 		"electron-builder": "^26.4.0",

--- a/src/electron/libs/runner.ts
+++ b/src/electron/libs/runner.ts
@@ -139,7 +139,7 @@ export async function runLetta(options: RunnerOptions): Promise<RunnerHandle> {
           lettaSession = resumeSession(cachedAgentId, sessionOptions);
         } else {
           debug("creating session: createSession (new agent, fallback)");
-          lettaSession = createSession(sessionOptions);
+          lettaSession = createSession(undefined, sessionOptions);
         }
       } else if (cachedAgentId) {
         // Create new conversation on existing agent
@@ -148,7 +148,7 @@ export async function runLetta(options: RunnerOptions): Promise<RunnerHandle> {
       } else {
         // First time - create new agent and session
         debug("creating session: createSession (new agent)");
-        lettaSession = createSession(sessionOptions);
+        lettaSession = createSession(undefined, sessionOptions);
       }
       debug("session created successfully");
 

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -19,10 +19,13 @@ if (!process.env.LETTA_API_KEY && process.env.LETTA_BASE_URL?.includes("localhos
 
 // Find letta CLI
 try {
-  const lettaPath = execSync("which letta", { encoding: "utf-8" }).trim();
+  const whichCmd = process.platform === 'win32' ? 'where letta' : 'which letta';
+  const lettaPath = execSync(whichCmd, { encoding: "utf-8" }).trim();
   if (lettaPath) {
-    process.env.LETTA_CLI_PATH = lettaPath;
-    console.log("Found letta CLI at:", lettaPath);
+    // On Windows, 'where' may return multiple lines - take the first one
+    const firstPath = lettaPath.split('\n')[0].trim();
+    process.env.LETTA_CLI_PATH = firstPath;
+    console.log("Found letta CLI at:", firstPath);
   }
 } catch (e) {
   console.warn("Could not find letta CLI:", e);


### PR DESCRIPTION
- Fix createSession() call to pass options as second parameter
- Use 'where' on Windows and 'which' on Unix for CLI detection
- Replace Unix-specific dev script with concurrently for cross-platform support

Generated with [Letta Code](https://letta.com)