### PR TITLE
Migrate to @letta-ai/letta-agent-sdk with local/remote/cloud backend support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,14 +1,33 @@
+# =====================================
+# Backend selection
+# =====================================
+# LETTA_BACKEND controls where agents live and where tools run:
+#   cloud  - agents stored in Letta Cloud, tools run on this machine (requires LETTA_API_KEY)
+#   local  - fully local runtime: agents stored on this machine, no API key needed
+#   remote - connect to a self-hosted Letta app server (see https://docs.letta.com/self-hosting)
+#
+# If unset, defaults to cloud when LETTA_API_KEY is set, otherwise local.
+
+# =====================================
 # Letta Cloud (recommended for most users)
+# =====================================
 # Get your API key from: https://app.letta.com/settings
+LETTA_BACKEND=cloud
 LETTA_API_KEY=your-api-key-here
-LETTA_BASE_URL=https://api.letta.com
 
-# Optional: Use a specific agent (defaults to LRU agent)
-# LETTA_AGENT_ID=agent-xxxxx
+# Optional: override the Letta API base URL
+# LETTA_BASE_URL=https://api.letta.com
 
 # =====================================
-# Local Development (advanced users)
+# Fully local runtime (no API key needed)
 # =====================================
-# Uncomment these lines to use a local Letta server instead:
-# LETTA_BASE_URL=http://localhost:8283
-# LETTA_API_KEY=dummy  # Local server ignores this
+# LETTA_BACKEND=local
+
+# =====================================
+# Self-hosted app server
+# =====================================
+# Start the server with: letta server --backend local --listen ws://127.0.0.1:4500
+# LETTA_BACKEND=remote
+# LETTA_SERVER_URL=ws://127.0.0.1:4500
+# Optional capability token if the server was started with --ws-auth:
+# LETTA_SERVER_TOKEN=your-token-here

--- a/README.md
+++ b/README.md
@@ -1,31 +1,31 @@
 <div align="center">
 
-# Demo open-source UI, built using the Letta Code SDK
+# Demo open-source UI, built using the Letta Agent SDK
 
 [![Platform](https://img.shields.io/badge/platform-%20macOS%20%7C%20Linux-lightgrey.svg)](https://github.com/letta-ai/letta-cowork/releases)
 
-An example desktop application for running Letta Code agents with a visual interface.
+An example desktop application for running Letta agents with a visual interface.
 
 </div>
 
 ## What is the Letta OSS UI?
 
-This repo contains an example desktop application for running Letta Code agents with a visual interface. The code is a fork of [Claude-Cowork](https://github.com/DevAgentForge/Claude-Cowork) that replaces the Claude SDK with the [`@letta-ai/letta-code-sdk`](https://www.npmjs.com/package/@letta-ai/letta-code-sdk). It provides a native desktop GUI for interacting with [Letta Code](https://github.com/letta-ai/letta-code) agents.
+This repo contains an example desktop application for running Letta agents with a visual interface. The code is a fork of [Claude-Cowork](https://github.com/DevAgentForge/Claude-Cowork) that replaces the Claude SDK with the [`@letta-ai/letta-agent-sdk`](https://www.npmjs.com/package/@letta-ai/letta-agent-sdk). It provides a native desktop GUI for interacting with [Letta](https://docs.letta.com/agent-sdk) agents.
 
 https://github.com/user-attachments/assets/570474a1-641b-404d-a1aa-50c080675773
 
-### Why Letta Code SDK?
+### Why Letta Agent SDK?
 
-The [Letta Code SDK](https://github.com/letta-ai/letta-code-sdk) is the SDK interface to [Letta Code](https://github.com/letta-ai/letta-code). Build agents with persistent memory that learn over time.
+The [Letta Agent SDK](https://docs.letta.com/agent-sdk) is the SDK interface to [Letta Code](https://github.com/letta-ai/letta-code). Build agents with persistent memory that learn over time.
 
 ```typescript
-import { createSession, resumeSession } from '@letta-ai/letta-code-sdk';
+import { createAgent, resumeSession } from '@letta-ai/letta-agent-sdk';
 
 // First session - agent learns something
-const session1 = createSession();
+const agentId = await createAgent();
+const session1 = resumeSession(agentId);
 await session1.send('Remember: the secret word is "banana"');
 for await (const msg of session1.stream()) { /* ... */ }
-const agentId = session1.agentId;
 session1.close();
 
 // Later... agent still remembers
@@ -48,8 +48,7 @@ Agents remember across conversations (via memory blocks), but each conversation 
 ### Prerequisites
 
 - [Bun](https://bun.sh/) or Node.js 22+
-- Letta API key from [app.letta.com/settings](https://app.letta.com/settings)
-- [letta-code-sdk](https://github.com/letta-ai/letta-code-sdk) cloned locally at `../letta-code-sdk` (temporary - will be published to npm)
+- For cloud mode: a Letta API key from [app.letta.com/settings](https://app.letta.com/settings)
 
 ### Environment Setup
 
@@ -58,15 +57,27 @@ Agents remember across conversations (via memory blocks), but each conversation 
    cp .env.example .env
    ```
 
-2. Get your Letta API key from [app.letta.com/settings](https://app.letta.com/settings)
+2. Pick a backend in `.env` (see `.env.example` for all options):
 
-3. Edit `.env` and add your API key:
+   **Letta Cloud** (agents stored in the cloud, tools run on your machine):
    ```bash
+   LETTA_BACKEND=cloud
    LETTA_API_KEY=your-api-key-here
-   LETTA_BASE_URL=https://api.letta.com  # This is the default
    ```
 
-**Note:** The app defaults to the Letta API (`https://api.letta.com`). For local development, see `.env.example` for localhost configuration.
+   **Fully local runtime** (agents stored on your machine, no API key):
+   ```bash
+   LETTA_BACKEND=local
+   ```
+
+   **Self-hosted app server** (see [self-hosting docs](https://docs.letta.com/self-hosting)):
+   ```bash
+   # In another terminal: letta server --backend local --listen ws://127.0.0.1:4500
+   LETTA_BACKEND=remote
+   LETTA_SERVER_URL=ws://127.0.0.1:4500
+   ```
+
+   If `LETTA_BACKEND` is unset, the app uses cloud when `LETTA_API_KEY` is set and local otherwise.
 
 ### Running the App
 
@@ -84,14 +95,15 @@ bun run dev
 
 ## Architecture
 
-The OSS UI uses [`@letta-ai/letta-code-sdk`](https://www.npmjs.com/package/@letta-ai/letta-code-sdk) to run agents.
+The OSS UI uses [`@letta-ai/letta-agent-sdk`](https://www.npmjs.com/package/@letta-ai/letta-agent-sdk) to run agents.
 
 ### How It Works
 
-1. The app spawns the Letta Code CLI as a subprocess via the SDK
-2. Communication happens via stdin/stdout JSON streaming
-3. Each task creates a new conversation on the LRU agent (via `createSession()`)
-4. Agent memory persists across conversations via memory blocks
+1. The app talks to a Letta app server through the SDK:
+   - `local` / `cloud` backends: the SDK spawns and manages a bundled local app server (`@letta-ai/letta-code`)
+   - `remote` backend: the SDK connects to your self-hosted app server over WebSocket
+2. Each task resumes the app's agent (created on first run) as a new SDK session
+3. Agent memory persists across conversations via memory blocks
 
 ## Development
 
@@ -102,4 +114,3 @@ bun run dev
 # Type checking
 bun run build
 ```
-

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -9,7 +9,7 @@
         "dist-electron/preload.cjs"
     ],
     "asarUnpack": [
-        "node_modules/@letta-ai/letta-code-sdk/**/*",
+        "node_modules/@letta-ai/letta-agent-sdk/**/*",
         "node_modules/@letta-ai/letta-code/**/*"
     ],
     "mac": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"dist:linux": "bun run transpile:electron && bun run build && electron-builder --linux --x64"
 	},
 	"dependencies": {
-		"@letta-ai/letta-code-sdk": "^0.0.5",
+		"@letta-ai/letta-agent-sdk": "^0.2.7",
 		"@radix-ui/react-dialog": "^1.1.15",
 		"@radix-ui/react-dropdown-menu": "^2.1.16",
 		"@tailwindcss/vite": "^4.1.18",

--- a/src/electron/libs/runner.ts
+++ b/src/electron/libs/runner.ts
@@ -1,10 +1,10 @@
 import {
-  createSession,
-  resumeSession,
-  type Session as LettaSession,
+  LettaAgentClient,
+  type LettaCodeClientOptions,
+  type LettaCodeSession,
   type SDKMessage,
   type CanUseToolResponse,
-} from "@letta-ai/letta-code-sdk";
+} from "@letta-ai/letta-agent-sdk";
 import type { ServerEvent } from "../types.js";
 import type { PendingPermission } from "./runtime-state.js";
 
@@ -48,15 +48,67 @@ const debug = (msg: string, data?: Record<string, unknown>) => {
   log(msg, data);
 };
 
+/**
+ * Resolve the SDK backend from environment variables:
+ *
+ * - LETTA_BACKEND=local  -> fully local runtime (agents stored on this machine)
+ * - LETTA_BACKEND=cloud  -> agents stored in Letta Cloud, tools run locally
+ *                           (requires LETTA_API_KEY)
+ * - LETTA_BACKEND=remote -> connect to a self-hosted app server
+ *                           (requires LETTA_SERVER_URL, e.g. ws://127.0.0.1:4500;
+ *                           optional LETTA_SERVER_TOKEN)
+ *
+ * If LETTA_BACKEND is unset: cloud when LETTA_API_KEY is set, local otherwise.
+ */
+function resolveClientOptions(): LettaCodeClientOptions {
+  const backend = (process.env.LETTA_BACKEND ?? "").toLowerCase();
+
+  if (backend === "remote") {
+    const url = process.env.LETTA_SERVER_URL;
+    if (!url) {
+      throw new Error(
+        "LETTA_BACKEND=remote requires LETTA_SERVER_URL (e.g. ws://127.0.0.1:4500)"
+      );
+    }
+    const token = process.env.LETTA_SERVER_TOKEN;
+    return {
+      backend: "remote",
+      url,
+      ...(token ? { authToken: token } : {}),
+    };
+  }
+
+  // Cloud mode requires the harness to be authenticated - either via
+  // LETTA_API_KEY or a previous `letta login` (the harness reports a clear
+  // error if neither is present).
+  const useCloudAgents =
+    backend === "cloud" || (backend !== "local" && !!process.env.LETTA_API_KEY);
+  return {
+    backend: "local",
+    appServer: { harnessBackend: useCloudAgents ? "api" : "local" },
+  };
+}
+
+let client: LettaAgentClient | null = null;
+
+function getClient(): LettaAgentClient {
+  if (!client) {
+    const options = resolveClientOptions();
+    debug("creating LettaAgentClient", { options: options as unknown as Record<string, unknown> });
+    client = new LettaAgentClient(options);
+  }
+  return client;
+}
+
 // Store active Letta sessions for abort handling
-let activeLettaSession: LettaSession | null = null;
+let activeLettaSession: LettaCodeSession | null = null;
 
 // Store agentId for reuse across conversations
 let cachedAgentId: string | null = null;
 
 export async function runLetta(options: RunnerOptions): Promise<RunnerHandle> {
   const { prompt, session, resumeConversationId, onEvent, onSessionUpdate } = options;
-  
+
   debug("runLetta called", {
     prompt: prompt.slice(0, 100) + (prompt.length > 100 ? "..." : ""),
     sessionId: session.id,
@@ -84,9 +136,10 @@ export async function runLetta(options: RunnerOptions): Promise<RunnerHandle> {
 
   // Start the query in the background
   (async () => {
+    let lettaSession: LettaCodeSession | null = null;
     try {
       // Common options for canUseTool
-      const canUseTool = async (toolName: string, input: unknown) => {
+      const canUseTool = async (toolName: string, input: Record<string, unknown>) => {
         // For AskUserQuestion, we need to wait for user response
         if (toolName === "AskUserQuestion") {
           const toolUseId = crypto.randomUUID();
@@ -109,51 +162,85 @@ export async function runLetta(options: RunnerOptions): Promise<RunnerHandle> {
       // Session options
       const sessionOptions = {
         cwd: session.cwd ?? DEFAULT_CWD,
-        permissionMode: "bypassPermissions" as const,
+        permissionMode: "unrestricted" as const,
         canUseTool,
       };
 
-      // Create or resume session
-      let lettaSession: LettaSession;
-
       // Validate that resumeConversationId looks like a valid Letta ID
-      // Valid IDs are: agent-xxx, conv-xxx, conversation-xxx, or UUIDs
+      // Valid IDs are: agent-xxx, conv-xxx, conversation-xxx, local-conv-xxx, or UUIDs
       const isValidLettaId = (id: string | undefined): boolean => {
         if (!id) return false;
         // Check for known prefixes or UUID format
-        return /^(agent-|conv-|conversation-|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/.test(id);
+        return /^(agent-|conv-|conversation-|local-conv-|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/.test(id);
+      };
+
+      const lettaClient = getClient();
+
+      // Workaround for a harness race: enabling memfs during createAgent() runs
+      // concurrent `git config` calls that collide on .git/config.lock. Create
+      // the agent without memfs, then enable it before the first turn.
+      let newAgentId: string | null = null;
+      const createAgentWithoutMemfs = async (): Promise<string> => {
+        const agentId = await lettaClient.createAgent({
+          cwd: sessionOptions.cwd,
+          memfs: false,
+        });
+        newAgentId = agentId;
+        return agentId;
+      };
+      const enableMemfs = async (agentId: string, target: LettaCodeSession) => {
+        const response = await target.sendCommand(
+          { type: "enable_memfs", agent_id: agentId },
+          { responseType: "enable_memfs_response", timeoutMs: 180000 }
+        );
+        if ((response as { success?: boolean }).success === false) {
+          log("WARNING: enable_memfs failed", { response: response as Record<string, unknown> });
+        }
       };
 
       if (resumeConversationId && isValidLettaId(resumeConversationId)) {
         // Resume specific conversation
         debug("creating session: resumeSession with conversationId", { resumeConversationId });
-        lettaSession = resumeSession(resumeConversationId, sessionOptions);
+        lettaSession = lettaClient.resumeSession(resumeConversationId, sessionOptions);
       } else if (resumeConversationId && !isValidLettaId(resumeConversationId)) {
         // Invalid ID provided - log warning and fall back to cachedAgentId
-        log("WARNING: invalid resumeConversationId, falling back", { 
-          invalidId: resumeConversationId, 
-          fallbackTo: cachedAgentId ? "cachedAgentId" : "createSession" 
+        log("WARNING: invalid resumeConversationId, falling back", {
+          invalidId: resumeConversationId,
+          fallbackTo: cachedAgentId ? "cachedAgentId" : "createAgent"
         });
         if (cachedAgentId) {
           debug("creating session: resumeSession with cachedAgentId (fallback)", { cachedAgentId });
-          lettaSession = resumeSession(cachedAgentId, sessionOptions);
+          lettaSession = lettaClient.resumeSession(cachedAgentId, sessionOptions);
         } else {
-          debug("creating session: createSession (new agent, fallback)");
-          lettaSession = createSession(undefined, sessionOptions);
+          debug("creating session: createAgent + createSession (new agent, fallback)");
+          cachedAgentId = await createAgentWithoutMemfs();
+          lettaSession = lettaClient.createSession(cachedAgentId, sessionOptions);
         }
       } else if (cachedAgentId) {
         // Create new conversation on existing agent
-        debug("creating session: resumeSession with cachedAgentId", { cachedAgentId });
-        lettaSession = resumeSession(cachedAgentId, sessionOptions);
+        debug("creating session: createSession with cachedAgentId", { cachedAgentId });
+        lettaSession = lettaClient.createSession(cachedAgentId, sessionOptions);
       } else {
         // First time - create new agent and session
-        debug("creating session: createSession (new agent)");
-        lettaSession = createSession(undefined, sessionOptions);
+        debug("creating session: createAgent + createSession (new agent)");
+        cachedAgentId = await createAgentWithoutMemfs();
+        debug("created agent", { agentId: cachedAgentId });
+        lettaSession = lettaClient.createSession(cachedAgentId, sessionOptions);
       }
       debug("session created successfully");
 
       // Store for abort handling
       activeLettaSession = lettaSession;
+
+      // Enable memfs on freshly created agents before the first turn
+      if (newAgentId) {
+        debug("enabling memfs on new agent", { agentId: newAgentId });
+        try {
+          await enableMemfs(newAgentId, lettaSession);
+        } catch (memfsError) {
+          log("WARNING: failed to enable memfs on new agent", { error: String(memfsError) });
+        }
+      }
 
       // Send the prompt (triggers init internally)
       debug("calling send()");
@@ -184,7 +271,7 @@ export async function runLetta(options: RunnerOptions): Promise<RunnerHandle> {
       for await (const message of lettaSession.stream()) {
         messageCount++;
         debug("received message", { type: message.type, count: messageCount });
-        
+
         // Send message directly to frontend (no transform needed)
         sendMessage(message);
 
@@ -214,17 +301,24 @@ export async function runLetta(options: RunnerOptions): Promise<RunnerHandle> {
         debug("session aborted");
         return;
       }
-      log("ERROR in runLetta", { 
-        error: String(error), 
+      log("ERROR in runLetta", {
+        error: String(error),
         name: (error as Error).name,
-        stack: (error as Error).stack 
+        stack: (error as Error).stack
       });
       onEvent({
         type: "session.status",
         payload: { sessionId: currentSessionId, status: "error", title: currentSessionId, error: String(error) }
       });
     } finally {
-      debug("runLetta finally block, clearing activeLettaSession");
+      debug("runLetta finally block, closing session");
+      // Sessions own their transport (e.g. a spawned local app-server process),
+      // so they must be closed to avoid leaking processes.
+      try {
+        lettaSession?.close();
+      } catch (closeError) {
+        debug("error closing session", { error: String(closeError) });
+      }
       activeLettaSession = null;
     }
   })();

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -7,29 +7,10 @@ import { ipcMainHandle, isDev, DEV_PORT } from "./util.js";
 // Load .env file from project root
 dotenvConfig({ path: join(process.cwd(), ".env") });
 
-// Default to Letta Cloud if no base URL set
-if (!process.env.LETTA_BASE_URL) {
-  process.env.LETTA_BASE_URL = "https://api.letta.com";
-}
-
-// Set dummy API key for localhost (local server doesn't check it)
-if (!process.env.LETTA_API_KEY && process.env.LETTA_BASE_URL?.includes("localhost")) {
-  process.env.LETTA_API_KEY = "local-dev-key";
-}
-
-// Find letta CLI
-try {
-  const whichCmd = process.platform === 'win32' ? 'where letta' : 'which letta';
-  const lettaPath = execSync(whichCmd, { encoding: "utf-8" }).trim();
-  if (lettaPath) {
-    // On Windows, 'where' may return multiple lines - take the first one
-    const firstPath = lettaPath.split('\n')[0].trim();
-    process.env.LETTA_CLI_PATH = firstPath;
-    console.log("Found letta CLI at:", firstPath);
-  }
-} catch (e) {
-  console.warn("Could not find letta CLI:", e);
-}
+// Backend selection (local runtime / remote app server / cloud) is resolved in
+// libs/runner.ts from LETTA_BACKEND, LETTA_API_KEY, and LETTA_SERVER_URL.
+// The SDK bundles its own Letta Code CLI (@letta-ai/letta-code); a user-set
+// LETTA_CLI_PATH still takes precedence if exported in the environment.
 import { getPreloadPath, getUIPath, getIconPath } from "./pathResolver.js";
 import { getStaticData, pollResources, stopPolling } from "./test.js";
 import { handleClientEvent, cleanupAllSessions } from "./ipc-handlers.js";

--- a/src/electron/types.ts
+++ b/src/electron/types.ts
@@ -12,7 +12,7 @@ export type {
   SDKReasoningMessage,
   SDKResultMessage,
   CanUseToolResponse,
-} from "@letta-ai/letta-code-sdk";
+} from "@letta-ai/letta-agent-sdk";
 
 export type UserPromptMessage = {
   type: "user_prompt";
@@ -20,7 +20,7 @@ export type UserPromptMessage = {
 };
 
 // Import for union type and local use
-import type { SDKMessage, CanUseToolResponse } from "@letta-ai/letta-code-sdk";
+import type { SDKMessage, CanUseToolResponse } from "@letta-ai/letta-agent-sdk";
 
 export type StreamMessage = SDKMessage | UserPromptMessage;
 

--- a/src/ui/components/EventCard.tsx
+++ b/src/ui/components/EventCard.tsx
@@ -299,6 +299,16 @@ export function MessageCard({
     case "tool_result":
       return <ToolResultCard message={sdkMessage} />;
     
+    case "error":
+      return (
+        <div className="flex flex-col gap-2 mt-4">
+          <div className="header text-error">Error</div>
+          <div className="rounded-xl bg-error-light p-3">
+            <pre className="text-sm text-error whitespace-pre-wrap">{sdkMessage.message}</pre>
+          </div>
+        </div>
+      );
+
     case "result":
       // Don't render session result
       if (sdkMessage.success) {

--- a/src/ui/store/useAppStore.ts
+++ b/src/ui/store/useAppStore.ts
@@ -206,40 +206,55 @@ export const useAppStore = create<AppState>((set, get) => ({
 
       case "stream.message": {
         const { sessionId, message } = event.payload;
+        const msgType = message.type;
+
+        // Protocol/progress messages the UI never renders - don't store them.
+        // (stream_event partials are handled separately in App.tsx.)
+        if (
+          msgType === "stream_event" ||
+          msgType === "loop_status" ||
+          msgType === "queue_update" ||
+          msgType === "retry"
+        ) {
+          break;
+        }
+
         set((state) => {
           const existing = state.sessions[sessionId] ?? createSession(sessionId);
           const messages = [...existing.messages];
-          
+
           // Get message ID (uuid for SDK messages)
           const msgId = 'uuid' in message ? message.uuid : undefined;
-          const msgType = message.type;
-          
-          if (msgId) {
-            // Find existing message with same ID
+          const last = messages[messages.length - 1];
+
+          if (
+            (msgType === "reasoning" || msgType === "assistant") &&
+            last &&
+            last.type === msgType
+          ) {
+            // Streaming chunks arrive as separate messages (each with its own
+            // uuid on the app-server transport) - merge consecutive chunks of
+            // the same type into a single message.
+            const lastContent = 'content' in last ? last.content : "";
+            const newContent = 'content' in message ? message.content : "";
+            messages[messages.length - 1] = {
+              ...message,
+              content: lastContent + newContent
+            } as StreamMessage;
+          } else if (msgId) {
+            // Find existing message with same ID (e.g. tool_call updates)
             const existingIdx = messages.findIndex(
               (m) => 'uuid' in m && m.uuid === msgId
             );
             if (existingIdx >= 0) {
-              // For streaming messages, ACCUMULATE content (SDK sends deltas)
-              if (msgType === "reasoning" || msgType === "assistant") {
-                const existingMsg = messages[existingIdx];
-                const existingContent = 'content' in existingMsg ? existingMsg.content : "";
-                const newContent = 'content' in message ? message.content : "";
-                messages[existingIdx] = {
-                  ...message,
-                  content: existingContent + newContent
-                } as StreamMessage;
-              } else {
-                // Other messages: replace
-                messages[existingIdx] = message;
-              }
+              messages[existingIdx] = message;
             } else {
               messages.push(message);
             }
           } else {
             messages.push(message);
           }
-          
+
           return {
             sessions: {
               ...state.sessions,

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -13,7 +13,7 @@ export type {
   SDKResultMessage,
   SDKStreamEventMessage,
   CanUseToolResponse,
-} from "@letta-ai/letta-code-sdk";
+} from "@letta-ai/letta-agent-sdk";
 
 export type UserPromptMessage = {
   type: "user_prompt";
@@ -21,7 +21,7 @@ export type UserPromptMessage = {
 };
 
 // Import for union type and local use
-import type { SDKMessage, CanUseToolResponse } from "@letta-ai/letta-code-sdk";
+import type { SDKMessage, CanUseToolResponse } from "@letta-ai/letta-agent-sdk";
 
 export type StreamMessage = SDKMessage | UserPromptMessage;
 


### PR DESCRIPTION
## Summary

Migrates the app from the deprecated `@letta-ai/letta-code-sdk@0.0.5` to the latest [`@letta-ai/letta-agent-sdk@0.2.7`](https://docs.letta.com/agent-sdk), and adds support for all three SDK backends per the [self-hosting docs](https://docs.letta.com/self-hosting).

### Backend configuration (`.env`)

| Mode | Config | Semantics |
|------|--------|-----------|
| Local runtime | `LETTA_BACKEND=local` | Agents stored on this machine, no API key |
| Letta Cloud | `LETTA_BACKEND=cloud` + `LETTA_API_KEY` | Agents in Letta Cloud, tools run locally |
| Self-hosted app server | `LETTA_BACKEND=remote` + `LETTA_SERVER_URL` (+ optional `LETTA_SERVER_TOKEN`) | Connects to `letta server --listen ws://...` |

If `LETTA_BACKEND` is unset: cloud when `LETTA_API_KEY` is set, local otherwise.

### Migration changes

- Package rename + type updates (`Session` → `LettaCodeSession`, `permissionMode: "bypassPermissions"` → `"unrestricted"`)
- Runner now uses `LettaAgentClient`; agents are created explicitly (app-server sessions require an agent id) and sessions are `close()`d so spawned app-server processes don't leak
- New tasks create a new conversation on the cached agent (`createSession(agentId)`), preserving per-task conversations; `local-conv-*` ids added to resume-id validation
- Removed the `which letta` CLI override in `main.ts` — the SDK bundles a matching `@letta-ai/letta-code` CLI (a user-exported `LETTA_CLI_PATH` still takes precedence)
- `electron-builder.json` asarUnpack updated for the new package names

### Bug fixes

- **Streaming rendered each chunk as a separate Assistant card**: the app-server transport emits assistant/reasoning deltas as separate messages with distinct uuids. The store now merges consecutive same-type chunks and skips unrendered protocol messages (`loop_status`, `queue_update`, `retry`, `stream_event`). SDK `error` messages now render in the feed.
- **Workaround for an upstream harness race** (reproduced on letta-code 0.28.17 and 0.28.18): enabling memfs during `createAgent()` runs concurrent `git config` calls that collide on `.git/config.lock` and fail 100% of the time. The runner creates agents with `memfs: false`, then enables memfs via the `enable_memfs` protocol command before the first turn. Should be removed once fixed upstream.

## Verification

- `bun run build` (tsc + vite) and `bun run transpile:electron` pass; remaining eslint errors are pre-existing in untouched UI files
- **Local runtime**: end-to-end through the runner — agent created, conversation created, response streamed, turn completed
- **Self-hosted app server**: started `letta server --listen ws://127.0.0.1:4500`, runner connected and completed a turn (`conv-…` created)
- **Cloud**: verified the auth error path surfaces cleanly in the UI when no credentials are present (this machine has no stored Letta cloud auth); the flow is otherwise identical to local with `harnessBackend: "api"`
- **Electron UI**: launched in dev, live session verified (session start, tool execution, streaming with merged chunks)